### PR TITLE
Avoid unnecessary list allocations in StationMonitor

### DIFF
--- a/Services/Monitoring/StationMonitor.cs
+++ b/Services/Monitoring/StationMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using TestPlan.Logic.Models;
 
 public class StationMonitor
@@ -57,9 +58,9 @@ public class StationMonitor
     #endregion
 
     #region Funciones para compartir con el MVVM el status y bindear al front
-    public IReadOnlyCollection<StationModel> GetAllStationStatuses() =>
-    _stationStatuses.Values.ToList();
-    public IReadOnlyCollection<SlotModel> GetAllSlotStatuses() =>
-        _slotStatuses.Values.ToList();
+    public IEnumerable<StationModel> GetAllStationStatuses() =>
+        _stationStatuses.Values;
+    public IEnumerable<SlotModel> GetAllSlotStatuses() =>
+        _slotStatuses.Values;
     #endregion
 }


### PR DESCRIPTION
## Summary
- Return enumerable collections of station and slot statuses directly instead of allocating lists
- Add missing using for System.Collections.Generic

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aff2458ba8832a94e4a6e451699513